### PR TITLE
MNT Add flag to skip setup check (for bioconda setup)

### DIFF
--- a/test.py
+++ b/test.py
@@ -45,11 +45,14 @@ def main(argv=None):
 
     # check if setup.py has been ran already -----------------------------------
     sys.stderr.write("\n1-- ran setup.py: ")
-    if os.path.isdir(relative_path+'db_mOTU'):
-        sys.stderr.write("done\n\n")
+    if "--skip-setup-check" in sys.argv:
+        sys.stderr.write("SKIPPED. As requested due to --skip-setup-check\n\n")
     else:
-        sys.stderr.write("ERROR. Run setup.py\n\n")
-        sys.exit(1)
+        if os.path.isdir(relative_path+'db_mOTU'):
+            sys.stderr.write("done\n\n")
+        else:
+            sys.stderr.write("ERROR. Run setup.py\n\n")
+            sys.exit(1)
 
 
     sys.stderr.write("2-- Tools and versions:\n")
@@ -90,55 +93,59 @@ def main(argv=None):
     #===========================================================================
     #==================== test metagenomic profiling ===========================
     # Run motus on a test file
-    test_file = relative_path+'db_mOTU/test0001.fastq'
-    ground_truth_file = relative_path+'db_mOTU/test0001.motus'
-    temp_file_profile = tempfile.NamedTemporaryFile(delete=False, mode="w")
+    sys.stderr.write("\n3-- Taxonomy profiling test:")
 
-    sys.stderr.write("\n3-- Taxonomy profiling test:\n")
-    sys.stderr.write("- Run motus (-v 1, only error messages):\n")
-
-    motus_command = "python "+relative_path+"motus profile -s "+test_file+" -g 1 -o "+temp_file_profile.name+" -v 1"
-    process = subprocess.Popen(motus_command.split(), stdout=subprocess.PIPE)
-    output, error = process.communicate()
-
-    sys.stderr.write("- end motus call\n")
-    sys.stderr.write("\nCheck resulting profile: ")
-    profiled = open(temp_file_profile.name,"r")
-    ground_truth = open(ground_truth_file,"r")
-
-    gt = list()
-    pr = list()
-    for i in profiled:
-        pr.append(i)
-    for i in ground_truth:
-        gt.append(i)
-    profiled.close()
-    ground_truth.close()
-
-    # check values
-    error_flag = False
-    if len(pr) != len(gt):
-        error_flag = True
-        sys.stderr.write("ERROR. profiled sample is not correct\n\n")
+    if "--skip-setup-check" in sys.argv:
+        sys.stderr.write("SKIPPED. Due to --skip-setup-check\n\n")
     else:
-        for i in range(1,len(pr)):
-            if i != 0 and i != 1 and i != 2: # do not check the first 3 lines
-                gt1 = gt[i].split("\t")[0]
-                gt2 = int(float(gt[i].rstrip().split("\t")[1]))
-                pr1 = pr[i].split("\t")[0]
-                pr2 = int(float(pr[i].rstrip().split("\t")[1]))
-                if (gt1 != pr1):
-                    error_flag = True
-                    sys.stderr.write("ERROR. Different values in line "+str(i+1)+":\n"+gt1+"\n"+pr1+" \n\n")
-                if (gt2 != pr2):
-                    error_flag = True
-                    sys.stderr.write("ERROR. Different values in line "+str(i+1)+":\n"+str(gt2)+"\n"+str(pr2)+" \n\n")
+        test_file = relative_path+'db_mOTU/test0001.fastq'
+        ground_truth_file = relative_path+'db_mOTU/test0001.motus'
+        temp_file_profile = tempfile.NamedTemporaryFile(delete=False, mode="w")
 
-    if not(error_flag):
-        sys.stderr.write("correct\n\n")
+        sys.stderr.write("\n- Run motus (-v 1, only error messages):\n")
 
-    # remove temp file
-    os.remove(temp_file_profile.name)
+        motus_command = "python "+relative_path+"motus profile -s "+test_file+" -g 1 -o "+temp_file_profile.name+" -v 1"
+        process = subprocess.Popen(motus_command.split(), stdout=subprocess.PIPE)
+        output, error = process.communicate()
+
+        sys.stderr.write("- end motus call\n")
+        sys.stderr.write("\nCheck resulting profile: ")
+        profiled = open(temp_file_profile.name,"r")
+        ground_truth = open(ground_truth_file,"r")
+
+        gt = list()
+        pr = list()
+        for i in profiled:
+            pr.append(i)
+        for i in ground_truth:
+            gt.append(i)
+        profiled.close()
+        ground_truth.close()
+
+        # check values
+        error_flag = False
+        if len(pr) != len(gt):
+            error_flag = True
+            sys.stderr.write("ERROR. profiled sample is not correct\n\n")
+        else:
+            for i in range(1,len(pr)):
+                if i != 0 and i != 1 and i != 2: # do not check the first 3 lines
+                    gt1 = gt[i].split("\t")[0]
+                    gt2 = int(float(gt[i].rstrip().split("\t")[1]))
+                    pr1 = pr[i].split("\t")[0]
+                    pr2 = int(float(pr[i].rstrip().split("\t")[1]))
+                    if (gt1 != pr1):
+                        error_flag = True
+                        sys.stderr.write("ERROR. Different values in line "+str(i+1)+":\n"+gt1+"\n"+pr1+" \n\n")
+                    if (gt2 != pr2):
+                        error_flag = True
+                        sys.stderr.write("ERROR. Different values in line "+str(i+1)+":\n"+str(gt2)+"\n"+str(pr2)+" \n\n")
+
+        if not(error_flag):
+            sys.stderr.write("correct\n\n")
+
+        # remove temp file
+        os.remove(temp_file_profile.name)
 
     return 0        # success
 


### PR DESCRIPTION
With bioconda the database has to be installed after (cannot be included with the package due to its size).

Testing that all dependencies are available is still useful so adding `--skip-setup-check` allows skipping testing if the DB is installed and if a profile can be generated (which also requires the DB)