### PR TITLE
Changes to ensure results are consistent in Py2 and Py3

### DIFF
--- a/bin/PEfiltering.py
+++ b/bin/PEfiltering.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import division
 import sys
 from collections import defaultdict
 import string

--- a/bin/append.py
+++ b/bin/append.py
@@ -5,6 +5,7 @@
 #
 # ============================================================================ #
 
+from __future__ import division
 import os
 import sys
 import argparse

--- a/bin/map_genes_to_mOTUs.py
+++ b/bin/map_genes_to_mOTUs.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import division
 import os
 import sys
 import argparse

--- a/bin/map_genes_to_mOTUs.py
+++ b/bin/map_genes_to_mOTUs.py
@@ -50,7 +50,7 @@ def printDictToFile(dictData, header, outfileName, return_dictionary):
 
         for key in dictData:
             value = dictData[key]
-            outfile.write(str(key) + "\t" + str(value) + "\n")
+            outfile.write("{0}\t{1:.10f}\n".format(key, value))
 
         # flush,sync and close
         try:
@@ -75,7 +75,7 @@ def printDictToFile(dictData, header, outfileName, return_dictionary):
 
         for key in dictData:
             value = dictData[key]
-            print(str(key) + "\t" + str(value))
+            print("{0}\t{1:.10f}".format(key, value))
 
 
 #parse gene location from a file formatted: GeneName \t ContigName \t GeneStart \t GeneEnd
@@ -201,7 +201,7 @@ def readSAMfile(strSAMfilename, msamPercID, msamminLength, msam_script, msamOver
         sys.exit(1)
 
 
-    msamtoolsCMD = "python "+msam_script+" "+str(msamPercID/100)+" "+str(msamminLength)+" "+str(msamOverlap) + " None"
+    msamtoolsCMD = "python {0} {1:.10f} {2} {3} None".format(msam_script, msamPercID/100, msamminLength, msamOverlap)
 
     #sys.stderr.write(msamtoolsCMD+"\n")
     msamtools_popenCMD = shlex.split(msamtoolsCMD)
@@ -1173,7 +1173,7 @@ def run_mOTUs_v2_mapping(listInputFiles, databaseDir, databasePrefix, sampleName
 
 
     ## check that the input files exists
-    if profile_mode == False:
+    if profile_mode is False:
         cont = 0
         for inputFile in listInputFiles:
             cont = cont + 1
@@ -1186,7 +1186,7 @@ def run_mOTUs_v2_mapping(listInputFiles, databaseDir, databasePrefix, sampleName
                     if verbose>=2: sys.stderr.write("[W::calc_mgc] Warning. File "+inputFile+" does not have extension \".bam\" or \".sam\" \n")
 
 
-    geneLocationFileName = os.path.sep.join([databaseDir,  databasePrefix + ".padded.coords"])
+    geneLocationFileName = os.path.sep.join([databaseDir, databasePrefix + ".padded.coords"])
     dictReference2geneLocation = getReferenceDict(geneLocationFileName)
 
     geneLengthFileName = os.path.sep.join([databaseDir, databasePrefix + ".genes.len"])
@@ -1257,7 +1257,7 @@ def run_mOTUs_v2_mapping(listInputFiles, databaseDir, databasePrefix, sampleName
 
 def main(argv=None):
 
-    parser = argparse.ArgumentParser(description='This program calculates mOTU abundances for one sample', add_help = True)
+    parser = argparse.ArgumentParser(description='This program calculates mOTU abundances for one sample', add_help=True)
     parser.add_argument('--inputFile', '-i', action="store", dest='listInputFiles', default="", help='name of input file(s); sam or bam formatted files. If it is a list: insert all files separated by a comma')
     parser.add_argument('--databaseDir', '-d', action="store", dest='databaseDir', default=".", help='name of database directory')
     parser.add_argument('--databasePrefix', '-p', action="store", dest='databasePrefix', default="mOTU.v2b", help='name of database (prefix)')

--- a/bin/map_mOTUs_to_LGs.py
+++ b/bin/map_mOTUs_to_LGs.py
@@ -379,22 +379,22 @@ def calculate_abundance(infile, LGs_map, LGs_map_l, specI_taxonomy, mOTULG_taxon
                     name = j+"\t" # mOTU id
                     name = name + all_val[1]# consensus_name
                     if print_NCBI_id: name = name + "\t"+all_val[0] # NCBI_tax_id
-                    name = name + "\t" + str(rel_ab_LGs_rel[j]) +"\n" # value
+                    name = "{0}\t{1:.10f}\n".format(name, rel_ab_LGs_rel[j]) # value
                     outfile.write(name)
                 else:
                     name = "{\"name\":\""+all_val[1]+"\",\n"
                     name = name + "                                       \"NCBI_id\":\""+all_val[0]+"\"}"
                     list_rows.append("            {\"id\":\""+j+"\", \"metadata\":"+name+"},\n")
-                    list_vals.append("["+str(rel_ab_LGs_rel[j])+"],\n")
+                    list_vals.append("[{0:.10f}],\n".format(rel_ab_LGs_rel[j]))
             elif j == "-1": # -1
                 name = "-1\t-1"
                 if print_NCBI_id: name = name + "\tNA"
-                name = name + "\t" +str(rel_ab_LGs_rel[j])+"\n"
+                name = "{0}\t{1:.10f}\n".format(name, rel_ab_LGs_rel[j]) # value
                 if not BIOM_output:
                     outfile.write(name)
                 else:
                     list_rows.append("            {\"id\":\"-1\", \"metadata\":{\"name\":\"unknown\",\n                                    \"NCBI_id\":\"NA\"}}\n")
-                    list_vals.append("["+str(rel_ab_LGs_rel[j])+"]]\n")
+                    list_vals.append("[{0:.10f}]]\n".format(rel_ab_LGs_rel[j]))
 
             else: # if it not in anyone (it should not happen)
                 if verbose>1: sys.stderr.write(" [W::calc_motu] Warning: find mOTU "+j+" that is not present in the taxonomy\n")
@@ -423,12 +423,12 @@ def calculate_abundance(infile, LGs_map, LGs_map_l, specI_taxonomy, mOTULG_taxon
                 # line to print
                 name = name + " ["+j+"]"
                 if print_NCBI_id: name = name + "\t"+all_val[0] # NCBI_tax_id
-                name = name + "\t" + str(rel_ab_LGs_rel[j]) +"\n" # value
+                name = "{0}\t{1:.10f}\n".format(name, rel_ab_LGs_rel[j]) # value
                 outfile.write(name)
             elif j == "-1": # -1
                 name = "-1"
                 if print_NCBI_id: name = name + "\tNA"
-                name = name + "\t" +str(rel_ab_LGs_rel[j])+"\n"
+                name = "{0}\t{1:.10f}\n".format(name, rel_ab_LGs_rel[j]) # value
                 outfile.write(name)
             else: # if it not in anyone (it should not happen)
                 if verbose>1: sys.stderr.write(" [W::calc_motu] Warning: find mOTU "+j+" that is not present in the taxonomy\n")
@@ -476,24 +476,24 @@ def calculate_abundance(infile, LGs_map, LGs_map_l, specI_taxonomy, mOTULG_taxon
                 # prepare line to print
                 name = all_val[1] # consensus_name
                 if print_NCBI_id: name = name + "\t"+all_val[0] # NCBI_tax_id
-                name = name + "\t" + str(rel_abundance_taxon[i]) +"\n" # value
+                name = "{0}\t{1:.10f}\n".format(name, rel_abundance_taxon[i]) # value
                 if not BIOM_output:
                     outfile.write(name)
                 else:
                     name = "{\"NCBI_id\":\""+all_val[0]+"\"}"
                     list_rows.append("            {\"id\":\""+all_val[1]+"\", \"metadata\":"+name+"},\n")
-                    list_vals.append("["+str(rel_abundance_taxon[i])+"],\n")
+                    list_vals.append("[{0:.10f}],\n".format(rel_abundance_taxon[i]))
 
             else:
                 if not BIOM_output:
                     if print_NCBI_id:
-                        name = "-1\tNA\t"+str(rel_abundance_taxon[i])+"\n"
+                        name = "-1\tNA\t{0:.10f}\n".format(rel_abundance_taxon[i])
                     else:
-                        name = "-1\t"+str(rel_abundance_taxon[i])+"\n"
+                        name = "-1\t{0:.10f}\n".format(rel_abundance_taxon[i])
                     outfile.write(name)
                 else:
                     list_rows.append("            {\"id\":\"-1\", \"metadata\":{\"NCBI_id\":\"NA\"}}\n")
-                    list_vals.append("["+str(rel_abundance_taxon[i])+"]]\n")
+                    list_vals.append("[{0:.10f}]]\n".format(rel_abundance_taxon[i]))
 
     ####### PRINT BIOM FORMAT ##################################################
     if BIOM_output:

--- a/bin/map_mOTUs_to_LGs.py
+++ b/bin/map_mOTUs_to_LGs.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import division
 import os
 import sys
 import argparse

--- a/bin/metaSNV_DistDiv.py
+++ b/bin/metaSNV_DistDiv.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+
+from __future__ import division
 import os
 import sys
 import argparse

--- a/bin/metaSNV_Filtering_2.0.py
+++ b/bin/metaSNV_Filtering_2.0.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+
+from __future__ import division
 import os
 import sys
 import argparse

--- a/bin/motu_utilities.py
+++ b/bin/motu_utilities.py
@@ -5,6 +5,7 @@
 #
 # ============================================================================ #
 
+from __future__ import division
 from itertools import islice
 from gzip import GzipFile
 from bz2 import BZ2File

--- a/bin/msamtools_python.py
+++ b/bin/msamtools_python.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import division
 import sys
 import re
 

--- a/bin/runBWA.py
+++ b/bin/runBWA.py
@@ -5,6 +5,7 @@
 #
 # ============================================================================ #
 
+from __future__ import division
 import os
 import sys
 import argparse

--- a/bin/runBWA_for_snv.py
+++ b/bin/runBWA_for_snv.py
@@ -5,6 +5,7 @@
 #
 # ============================================================================ #
 
+from __future__ import division
 import os
 import sys
 import argparse

--- a/motus
+++ b/motus
@@ -30,6 +30,7 @@
 # ============================================================================ #
 
 
+from __future__ import division
 import os
 import sys
 import argparse

--- a/motus
+++ b/motus
@@ -1389,8 +1389,8 @@ def main(argv=None):
                     os.chmod(mgc_temp_file.name, 0o644)
                     mgc_temp_file.write(mgc_table_header+"\n")
                     mgc_temp_file.write(sample_name+"\n")
-                    for i in sorted(mOTU_counts):
-                        mgc_temp_file.write(i+"\t"+str(mOTU_counts[i])+"\n")
+                    for m, value in sorted(mOTU_counts.items()):
+                        mgc_temp_file.write("{0}\t{1:.10f}\n".format(m, value))
                 except:
                     sys.stderr.write("[W::main] Warning: failed to save the intermediate mgc table\n")
 

--- a/motus
+++ b/motus
@@ -1388,7 +1388,7 @@ def main(argv=None):
                     os.chmod(mgc_temp_file.name, 0o644)
                     mgc_temp_file.write(mgc_table_header+"\n")
                     mgc_temp_file.write(sample_name+"\n")
-                    for i in mOTU_counts:
+                    for i in sorted(mOTU_counts):
                         mgc_temp_file.write(i+"\t"+str(mOTU_counts[i])+"\n")
                 except:
                     sys.stderr.write("[W::main] Warning: failed to save the intermediate mgc table\n")


### PR DESCRIPTION
Please check in detail the impact of https://github.com/motu-tool/mOTUs_v2/commit/ae13d2832306158f668d74206c71faa7cff4a1a9

This adds additional zeros to the output but is the only way (I found so far) to ensure profiles generated by different python versions are consistent.

Also https://github.com/motu-tool/mOTUs_v2/commit/4ac9c3c254a47624ca12d3463fee0626ba432d72 forces `x/y` to always behave like `x/float(y)` which is the default behavior in Py3 and is safer than explicitly calling `float()` every time a division happens.