### PR TITLE
Enable testing through testing/binaries repositories

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,40 @@
+image: ubuntu
+
+# on_finish:
+#  - sh: export APPVEYOR_SSH_BLOCK=true
+#  - sh: curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
+
+environment:
+  # APPVEYOR_SSH_KEY: ssh-rsa <insert hash here>
+  matrix:
+    - PYTHON_VERSION: 2.7
+    - PYTHON_VERSION: 3.4
+    - PYTHON_VERSION: 3.5
+    - PYTHON_VERSION: 3.6
+    - PYTHON_VERSION: 3.7
+
+install:
+  - sudo apt-get install -y -q biom-format-tools
+  # Clone testing repository
+  - git clone --depth 1 git://github.com/motu-tool/mOTUs_v2_testing.git
+  - sh: echo "Testing with $(git --git-dir mOTUs_v2_testing/.git log --format='%C(auto) %h %s' -1)"
+  # Clone static binaries repository
+  - git clone --depth 1 git://github.com/motu-tool/mOTUs_v2_binaries.git
+  - sh: echo "Binaries from $(git --git-dir mOTUs_v2_binaries/.git log --format='%C(auto) %h %s' -1)"
+  # Setup $PATH so everything above gets used
+  - sh: export PATH=$APPVEYOR_BUILD_FOLDER:$APPVEYOR_BUILD_FOLDER/mOTUs_v2_binaries:$PATH
+  # Use appveyor's provided virtualenvs
+  - sh: source ~/venv$PYTHON_VERSION*/bin/activate
+
+cache:
+  - db_mOTU -> setup.py  # Cache db_mOTU/ but expire it if setup.py (which contains database version information) changes
+  - test -> setup.py  # Cache test/ but expire it if setup.py (which contains database version information) changes
+
+build: off
+
+test_script:
+  - python --version
+  - python setup.py --no-download-progress
+  - python test.py
+  - motus --version
+  - cd mOTUs_v2_testing && python run_all -v

--- a/motus
+++ b/motus
@@ -479,7 +479,7 @@ def main(argv=None):
                         help="FILTERING STEP II:"
                              "required proportion of informative samples (coverage non-zero) per position",
                         default=None)
-    parser.add_argument('--version', action='version', version='%(prog)s '+version_tool)
+    parser.add_argument('--version', action='version', version='%(prog)s {0} on python {1}'.format(version_tool, sys.version.split()[0]))
 
     args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,10 @@ def main(argv=None):
 
     # move the test dir outside db dir -----------------------------------------
     sys.stderr.write("Move test directory...")
+    testdir = relative_path+"test"
+    if os.path.isdir(testdir):
+        shutil.rmtree(testdir, ignore_errors=True)
+
     try:
         shutil.move(relative_path+"db_mOTU/test", relative_path)
     except (shutil.Error, OSError) as e:


### PR DESCRIPTION
Fixes a small mistake with the move of the test directory.

Configures testing through Appveyor ([example](https://ci.appveyor.com/project/unode/motus-v2)).
To enable you need to [login to Appveyor](https://ci.appveyor.com) using github credentials and then add this repository as a [new project](https://ci.appveyor.com/projects/new).