### PR TITLE
Expose database path to CLI with '-db PATH'

### DIFF
--- a/motus/mentities.py
+++ b/motus/mentities.py
@@ -430,8 +430,8 @@ class MotusDB:
         """
         logging.info('Loading database ... ')
 
-        if not mutils.DEFAULT_MOTUS_MGDB_LOCATION_MARKER.exists():
-            logging.error('mOTUs marker gene database not downloaded. Download database with "motus downloadMGDB"')
+        if not mOTUsdb_folder.joinpath('db_mOTU.downloaded').exists():
+            logging.error(f'mOTUs marker gene database not found at {mOTUsdb_folder}. Download database with "motus downloadMGDB"')
             mutils.shutdown(1)
 
         versions_file = mOTUsdb_folder.joinpath('mOTUsv4.0.db').resolve()

--- a/motus/motus.py
+++ b/motus/motus.py
@@ -174,9 +174,9 @@ def map_tax() -> None:
     logging.info(f'Finished all alignments. Total reads: {total_reads}, Total aligned reads {total_mapped_reads}, {round(total_mapped_reads * 100.0 / total_reads, 4)}%')
     temp_bam_file_handle.close()
 
-    logging.info(f'Sorting BAM file')
+    logging.info('Sorting BAM file')
     pysam.sort('-n', '-m', '1G', '-@', '1', '-o', str(MOTUS_PARAMETERS.get_alignment_file()),  str(MOTUS_PARAMETERS.get_temporary_alignment_file()))
-    logging.info(f'Finished sorting BAM file')
+    logging.info('Finished sorting BAM file')
 
     MOTUS_PARAMETERS.delete_temporary_alignment_file()
     logging.info('Finished mOTUs - map_tax routine - Alignment against the mOTUs database ...')
@@ -673,7 +673,7 @@ class InsertCounter:
                     minlength = int(minlength.split('-l')[-1].strip())
         if motus_found:
             if MOTUS_DB.get_full_version() != database_tool:
-                logging.error(f'Version of BAM file and databases don\'t match')
+                logging.error('Version of BAM file and databases don\'t match')
                 logging.error(f'BAM: {database_tool}')
                 logging.error(f'Database/Tool: {MOTUS_DB.get_full_version()}')
                 mutils.shutdown(1)
@@ -683,7 +683,7 @@ class InsertCounter:
                              f'. Increase minimum alignment length to continue.')
                 mutils.shutdown(1)
         else:
-            logging.error(f'BAM file invalid as it was not generated with mOTUs4')
+            logging.error('BAM file invalid as it was not generated with mOTUs4')
             mutils.shutdown(1)
 
 
@@ -936,13 +936,16 @@ def parse_map_tax():
 
         -t, --threads  INT
             Number of threads (default: 1)
+
+    Database options:
+        -db, --database  DIR
+            Path to the mOTUs marker gene database directory (default: installation directory)
           ''', formatter_class=CapitalisedHelpFormatter,add_help=False)
 
     # Input options
     parser.add_argument("-f", "--forward", nargs="+",default=[], dest='f')  # input files(s) for reads in forward orientation, fastq(.gz)-formatted
     parser.add_argument("-r", "--reverse", nargs="+",default=[], dest='r')  # input files(s) for reads in reverse orientation, fastq(.gz)-formatted
     parser.add_argument("-s", "--single", nargs="+", default=[], dest='s')  # input files(s) for unpaired reads, fastq(.gz)-formatted
-    #parser.add_argument("-db")  # provide a different database directory
 
     # Output options
     parser.add_argument("-o", "--output-file", required=True, dest='o')  # output file name
@@ -951,6 +954,9 @@ def parse_map_tax():
     # ALgorithm options
     parser.add_argument("-l", "--alignment-length",  type=int, default=75, dest='l')  # min length of the alignment (bp) [75]
     parser.add_argument("-t", "--threads", type=int, default=1, dest='t')  # number of threads
+
+    # Database options (added support for -db/--database)
+    parser.add_argument("-db", "--database", type=str, default=None, dest='db')
 
     args = parser.parse_args(sys.argv[2:])
 
@@ -967,8 +973,10 @@ def parse_map_tax():
     mutils.startup()
     threads = args.t
     min_alignment_length = args.l
+    # Database location
+    db_location = pathlib.Path(args.db) if args.db else mutils.DEFAULT_MOTUS_MGDB_LOCATION
 
-    MOTUS_DB.load_motus_db(mutils.DEFAULT_MOTUS_MGDB_LOCATION)
+    MOTUS_DB.load_motus_db(db_location)
 
 
 
@@ -1002,6 +1010,9 @@ def parse_batch_profile():
        -l  INT          min length of the alignment (bp) [75]
        -y  STR          type of read counts [INSERT_SCALED]
                         Values: [INSERT_RAW, INSERT_NORM, INSERT_SCALED, BASE_RAW, BASE_NORM]
+
+    Database options:
+       -db  DIR         path to the mOTUs marker gene database directory (default: installation directory)
     ]''', formatter_class=CapitalisedHelpFormatter, add_help=False)
 
     # Input options
@@ -1013,6 +1024,7 @@ def parse_batch_profile():
     parser.add_argument("-t", type=int, default=1)  # number of thread [1]
     parser.add_argument("-y", type=str, default='INSERT_SCALED',
                         choices=['INSERT_RAW', 'INSERT_NORM', 'INSERT_SCALED', 'BASE_RAW', 'BASE_NORM'])
+    parser.add_argument("-db", "--database", type=str, default=None, dest='db')
 
     args = parser.parse_args(sys.argv[2:])
     if sys.argv[2:] == []:
@@ -1048,9 +1060,9 @@ def parse_batch_profile():
     mutils.startup()
     threads = args.t
     min_alignment_length = args.l
+    db_location = pathlib.Path(args.db) if args.db else mutils.DEFAULT_MOTUS_MGDB_LOCATION
 
-
-    MOTUS_DB.load_motus_db(mutils.DEFAULT_MOTUS_MGDB_LOCATION)
+    MOTUS_DB.load_motus_db(db_location)
 
     for samplename, (bamfile, mgc_file, motu_file, inserts_file) in samplename_2_files.items():
 
@@ -1119,6 +1131,10 @@ def parse_profile():
         -y, --counting-mode  STR
             Which scale the abundances are reported in (default: INSERT_SCALED)
             Choices: [INSERT_RAW, INSERT_NORM, INSERT_SCALED, BASE_RAW, BASE_NORM]
+
+    Database options:
+        -db, --database  DIR
+            Path to the mOTUs marker gene database directory (default: installation directory)
     ''', formatter_class=CapitalisedHelpFormatter,add_help=False)
 
     # Input options
@@ -1134,6 +1150,9 @@ def parse_profile():
     parser.add_argument("-t", "--threads",  type=int, default=1, dest='t')  # number of thread [1]
     parser.add_argument("-y", "--counting-mode", type=str, default='INSERT_SCALED', choices=['INSERT_RAW', 'INSERT_NORM', 'INSERT_SCALED', 'BASE_RAW', 'BASE_NORM'], dest='y')
     #parser.add_argument("-c", action="store_true", help="Write second output file with relative abundances")
+
+    # Database options
+    parser.add_argument("-db", "--database", type=str, default=None, dest='db')
 
     args = parser.parse_args(sys.argv[2:])
     if sys.argv[2:] == []:
@@ -1152,9 +1171,9 @@ def parse_profile():
     threads = args.t
     min_alignment_length = args.l
     samplename = args.n
+    db_location = pathlib.Path(args.db) if args.db else mutils.DEFAULT_MOTUS_MGDB_LOCATION
 
-
-    MOTUS_DB.load_motus_db(mutils.DEFAULT_MOTUS_MGDB_LOCATION)
+    MOTUS_DB.load_motus_db(db_location)
 
 
     MOTUS_PARAMETERS.set_read_files(forward_files, reverse_files, unpaired_files, check_files=True)
@@ -1201,11 +1220,16 @@ def parse_calc_mgc():
     Algorithm options:
         -l, --alignment-length  INT
             Minimum length of the alignment (bp) (default: 75)
+
+    Database options:
+        -db, --database  DIR
+            Path to the mOTUs marker gene database directory (default: installation directory)
        ''', formatter_class=CapitalisedHelpFormatter,add_help=False)
 
     parser.add_argument("-i", "--input-file", type=str, required=True, dest='i')  # provide a SAM or BAM input file (or list of files) output of motus map_tax
     parser.add_argument("-o", "--output-file", required=True, dest='o')  # output file name [stdout]
     parser.add_argument("-l", "--alignment-length", type=int, default=75, dest='l')  # min length of the alignment (bp) [75]
+    parser.add_argument("-db", "--database", type=str, default=None, dest='db')
 
     args = parser.parse_args(sys.argv[2:])
     # print usage and exit if no arguments are passed
@@ -1220,8 +1244,9 @@ def parse_calc_mgc():
 
     mutils.startup()
     min_alignment_length = args.l
+    db_location = pathlib.Path(args.db) if args.db else mutils.DEFAULT_MOTUS_MGDB_LOCATION
 
-    MOTUS_DB.load_motus_db(mutils.DEFAULT_MOTUS_MGDB_LOCATION)
+    MOTUS_DB.load_motus_db(db_location)
 
     MOTUS_PARAMETERS.set_alignment_file(alignment_file, required_to_exist=True)
     MOTUS_PARAMETERS.set_mgc_file(mgc_file,required_to_exist=False)
@@ -1261,12 +1286,16 @@ def parse_merge():
     Output options:
         -o, --output-file  FILE
             Output file name [required]
+
+    Database options:
+        -db, --database  DIR
+            Path to the mOTUs marker gene database directory (default: installation directory)
           ''', formatter_class=CapitalisedHelpFormatter, add_help=False)
 
 
     parser.add_argument("-i", "--input-files", nargs="+", required=True, dest='i')
-
     parser.add_argument("-o", "--output-file", required=True, dest='o')
+    parser.add_argument("-db", "--database", type=str, default=None, dest='db')
     args = parser.parse_args(sys.argv[2:])
 
     if sys.argv[2:] == []:
@@ -1287,8 +1316,9 @@ def parse_merge():
 
 
     input_mOTUs_files = sorted(input_mOTUs_files)
+    db_location = pathlib.Path(args.db) if args.db else mutils.DEFAULT_MOTUS_MGDB_LOCATION
 
-    MOTUS_DB.load_motus_db(mutils.DEFAULT_MOTUS_MGDB_LOCATION)
+    MOTUS_DB.load_motus_db(db_location)
 
     merge_profiles(input_mOTUs_files, output_mOTUs_file)
 
@@ -1524,12 +1554,17 @@ def parse_classify():
     Algorithm options:
         -t, --threads  INT
             Number of threads (default: 1)
+
+    Database options:
+        -db, --database  DIR
+            Path to the mOTUs marker gene database directory (default: installation directory)
            ''', formatter_class=CapitalisedHelpFormatter, add_help=False)
 
 
     parser.add_argument("-i", "--input-file", required=True, dest='i')
     parser.add_argument("-o", "--output-file", required=True, dest='o')
     parser.add_argument("-t", "--threads", default=1, type=int, dest='t')
+    parser.add_argument("-db", "--database", type=str, default=None, dest='db')
     args = parser.parse_args(sys.argv[2:])
 
     if sys.argv[2:] == []:
@@ -1546,13 +1581,14 @@ def parse_classify():
                 mutils.shutdown(1)
             genome_files.append(genome_file)
     output_file = args.o
+    db_location = pathlib.Path(args.db) if args.db else mutils.DEFAULT_MOTUS_MGDB_LOCATION
 
-    classify(genome_files, output_file, args.t)
+    classify(genome_files, output_file, args.t, db_location)
     mutils.shutdown(0)
 
 
 
-def classify(genome_files: List[pathlib.Path], output_file: pathlib.Path, threads: int = 1):
+def classify(genome_files: List[pathlib.Path], output_file: pathlib.Path, threads: int = 1, db_location: pathlib.Path = None):
     """Takes a list of genome files and associates them with existing mOTUs.
     A genome can either be:
     - classified with a mOTU (=mOTUXXX)
@@ -1563,14 +1599,17 @@ def classify(genome_files: List[pathlib.Path], output_file: pathlib.Path, thread
         genome_files (List[pathlib.Path]): A list with pathlib.Path objects all pointing to an existing genome file
         output_file (pathlib.Path): Main output file of motus classify
         threads (int, optional): Number of threads. Defaults to 1.
-    """    
+        db_location (pathlib.Path, optional): Path to the mOTUs database directory. Defaults to installation directory.
+    """
 
+    if db_location is None:
+        db_location = mutils.DEFAULT_MOTUS_MGDB_LOCATION
     genome_files = sorted(genome_files)
     root_tmp_folder =  pathlib.Path(str(output_file) + '_classify_tmp')
 
 
     logging.info(f'Starting mOTUs classify:')
-    MOTUS_DB.load_motus_db(mutils.DEFAULT_MOTUS_MGDB_LOCATION, True)
+    MOTUS_DB.load_motus_db(db_location, True)
     logging.info(f'\tInput = {len(genome_files)} genomes.')
     logging.info(f'\tOutput will be written to {output_file}')
     logging.info(f'\tTemporary files will be written to {root_tmp_folder}')
@@ -1772,9 +1811,14 @@ def parse_downloadDB():
     Options:
         -f, --force
             Force download even when database is already present
+
+        -db, --database  DIR
+            Path to the directory where the database will be downloaded (default: installation directory).
+            The database will be placed in a subdirectory named 'db_mOTU' inside this path.
            ''', formatter_class=CapitalisedHelpFormatter, add_help=False)
 
     parser.add_argument("-f", "--force", action="store_true", dest='f')
+    parser.add_argument("-db", "--database", type=str, default=None, dest='db')
     args = parser.parse_args(sys.argv[2:])
 
     force_download = False
@@ -1783,15 +1827,24 @@ def parse_downloadDB():
 
     mutils.startup()
 
-    if mutils.DEFAULT_MOTUS_MGDB_LOCATION_MARKER.exists() and not force_download:
+    if args.db:
+        db_parent_location = pathlib.Path(args.db)
+        db_location = db_parent_location.joinpath('db_mOTU')
+    else:
+        db_parent_location = mutils.DEFAULT_MOTUS_MGDB_PARENT_LOCATION
+        db_location = mutils.DEFAULT_MOTUS_MGDB_LOCATION
+    db_marker = db_location.joinpath('db_mOTU.downloaded')
+
+    if db_marker.exists() and not force_download:
         logging.info('Database already downloaded and -f not set. All good.')
         mutils.shutdown(0)
-    if mutils.DEFAULT_MOTUS_MGDB_LOCATION_MARKER.exists() and force_download:
+    if db_marker.exists() and force_download:
         logging.info('Database already downloaded and -f set. Will delete current database and download again.')
-        shutil.rmtree(mutils.DEFAULT_MOTUS_MGDB_LOCATION)
+        shutil.rmtree(db_location)
 
+    db_parent_location.mkdir(parents=True, exist_ok=True)
     logging.info('Start downloading mOTUs marker gene database. ~6GB')
-    dest_tar_gz_file = mutils.DEFAULT_MOTUS_MGDB_PARENT_LOCATION.joinpath('db_mOTU.tar.gz')
+    dest_tar_gz_file = db_parent_location.joinpath('db_mOTU.tar.gz')
     if dest_tar_gz_file.is_file():
         dest_tar_gz_file.unlink()
 
@@ -1805,17 +1858,17 @@ def parse_downloadDB():
                     break
                 f.write(chunk)
                 pbar.update(len(chunk))
-    
- 
+
+
     logging.info('Finished downloading mOTUs marker gene database.')
     logging.info('Start un-taring mOTUs marker gene database.')
-    if mutils.DEFAULT_MOTUS_MGDB_LOCATION.exists():
-        shutil.rmtree(mutils.DEFAULT_MOTUS_MGDB_LOCATION)
+    if db_location.exists():
+        shutil.rmtree(db_location)
 
     with tarfile.open(dest_tar_gz_file, 'r') as t:
-        t.extractall(mutils.DEFAULT_MOTUS_MGDB_PARENT_LOCATION)
+        t.extractall(db_parent_location)
 
-    mutils.DEFAULT_MOTUS_MGDB_LOCATION_MARKER.touch(exist_ok=True)
+    db_marker.touch(exist_ok=True)
     logging.info('Finished untaring mOTUs marker gene database.')
     mutils.shutdown(0)
 
@@ -1847,12 +1900,17 @@ def parse_download():
 
         -r, --representatives
             Download only sequences from representative genomes.
+
+    Database options:
+        -db, --database  DIR
+            Path to the mOTUs marker gene database directory (default: installation directory)
            ''', formatter_class=CapitalisedHelpFormatter, add_help=False)
 
 
     parser.add_argument("-o", "--output-folder", required=True, dest='o')
     parser.add_argument("-i", "--input-genomes", required=True, nargs="+", dest='i')
     parser.add_argument("-r", "--representatives", action="store_true", dest='r')
+    parser.add_argument("-db", "--database", type=str, default=None, dest='db')
 
 
     args = parser.parse_args(sys.argv[2:])
@@ -1867,7 +1925,7 @@ def parse_download():
     download_representative_genomes_only = False
     if args.r:
         download_representative_genomes_only = True
-    
+
     genomes_to_download = []
     if len(input_items) == 1: # can be a single genome or a file with genomes
         input_item = input_items[0]
@@ -1882,7 +1940,8 @@ def parse_download():
     else: # list of genomes
         genomes_to_download = input_items
 
-    MOTUS_DB.load_motus_db(mutils.DEFAULT_MOTUS_MGDB_LOCATION, load=False)
+    db_location = pathlib.Path(args.db) if args.db else mutils.DEFAULT_MOTUS_MGDB_LOCATION
+    MOTUS_DB.load_motus_db(db_location, load=False)
     motus_search_db = mentities.GenomeLocator(MOTUS_DB.genome_metadata_file)
     download_genomes(genomes_to_download, motus_search_db, output_folder, download_representative_genomes_only)
     mutils.shutdown(0)
@@ -1925,6 +1984,10 @@ def parse_calc_motu():
         -y, --counting-mode  STR
             Which scale the abundances are reported in (default: INSERT_SCALED)
             Choices: [INSERT_RAW, INSERT_NORM, INSERT_SCALED, BASE_RAW, BASE_NORM]
+
+    Database options:
+        -db, --database  DIR
+            Path to the mOTUs marker gene database directory (default: installation directory)
           ''', formatter_class=CapitalisedHelpFormatter,add_help=False)
 
 
@@ -1934,6 +1997,7 @@ def parse_calc_motu():
     parser.add_argument("-y", "--counting-mode", type=str, default='INSERT_SCALED', choices=['INSERT_RAW', 'INSERT_NORM', 'INSERT_SCALED', 'BASE_RAW', 'BASE_NORM'], dest='y')
     parser.add_argument("-g", "--marker-genes", type=int, default=3, choices=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dest='g')  # number of marker genes cutoff
     #parser.add_argument("-c", action="store_true",help="Write second output file with relative abundances")
+    parser.add_argument("-db", "--database", type=str, default=None, dest='db')
 
     args = parser.parse_args(sys.argv[2:])
     if sys.argv[2:] == []:
@@ -1945,9 +2009,9 @@ def parse_calc_motu():
     motu_file = pathlib.Path(args.o)
     mutils.startup()
     samplename = args.n
+    db_location = pathlib.Path(args.db) if args.db else mutils.DEFAULT_MOTUS_MGDB_LOCATION
 
-
-    MOTUS_DB.load_motus_db(mutils.DEFAULT_MOTUS_MGDB_LOCATION)
+    MOTUS_DB.load_motus_db(db_location)
 
     MOTUS_PARAMETERS.set_mgc_file(mgc_file, required_to_exist=True)
     MOTUS_PARAMETERS.set_motu_file(motu_file, required_to_exist=False)


### PR DESCRIPTION
As mentioned in #147

1. `motus downloadMGDB` would download to default location unless `-db` is given.
2. `motus profile` would get the db from the default location unless `-db` specifies otherwise.